### PR TITLE
Enhance javascript detection logic for raw style manipulation

### DIFF
--- a/core/src/main/java/com/salesforce/slds/validation/utils/JavascriptValidationUtilities.java
+++ b/core/src/main/java/com/salesforce/slds/validation/utils/JavascriptValidationUtilities.java
@@ -66,7 +66,7 @@ public class JavascriptValidationUtilities {
     }
 
     public Set<ProcessingItem> getStyleValues(Block block, List<String> rawContent) {
-        Pattern SLDS = Pattern.compile("slds-[^\\s\"\';\\.]*");
+        Pattern SLDS = Pattern.compile("slds-[^\\s\"\';\\.,:\\)\\[]*");
         Matcher matcher = SLDS.matcher(block.getValue());
 
         Set<String> styles = new LinkedHashSet<>();

--- a/core/src/test/resources/javascript/es6.js
+++ b/core/src/test/resources/javascript/es6.js
@@ -19,6 +19,6 @@ export default class App extends LightningElement {
     };
 
     get style() {
-        return 'slds-p-top_none';
+        return '.slds-p-top_none[data-selected=false], .slds-context-bar__item:not(.slds-item):hover';
     }
 }


### PR DESCRIPTION
Better SLDS detection when engineer is doing raw style manipulation within javascript logic.

For example:

```javascript
getStyles: function(color) {
  var rules = [
     '.slds-context-bar { border-bottom-color: ' + color + '}',
     '.slds-context-bar__item:not(.slds-no-hover):not(.slds-is-active):hover { border-bottom-color: ' + color + ' }',
     '.slds-context-bar__item.slds-is-active:before { background-color: ' + color + ' }',
     '.slds-context-bar__item.slds-is-active { background-color: ' + rgbaBackgound + '}',
  ];
  return rules.join('');
}
```