### PR TITLE
Better Dynamic Elements Support

### DIFF
--- a/core/src/main/java/com/salesforce/slds/validation/validators/impl/recommendation/UtilityClassValidator.java
+++ b/core/src/main/java/com/salesforce/slds/validation/validators/impl/recommendation/UtilityClassValidator.java
@@ -79,7 +79,7 @@ public class UtilityClassValidator implements RecommendationValidator, Initializ
 
             recommendations.addAll(entry.getInputs().stream()
                     .filter(input -> input.getType() == Input.Type.STYLE)
-                    .map(input -> match(entry.getComponentName(), input.asRuleSet(), elements))
+                    .map(input -> match(entry, input.asRuleSet(), elements))
                     .filter(Objects::nonNull).collect(Collectors.toList()));
 
         }
@@ -87,7 +87,7 @@ public class UtilityClassValidator implements RecommendationValidator, Initializ
         return recommendations;
     }
 
-    Recommendation match(String componentName, RuleSet ruleSet, List<HTMLElement> elements) {
+    Recommendation match(Entry entry, RuleSet ruleSet, List<HTMLElement> elements) {
         /**
          * For ruleSet,
          * - determines which utility classes are applicable
@@ -98,7 +98,7 @@ public class UtilityClassValidator implements RecommendationValidator, Initializ
          *      - update elements with corresponding update
          */
 
-        final Map<Selector, List<HTMLElement>> selectedElements = sort(componentName, ruleSet, elements);
+        final Map<Selector, List<HTMLElement>> selectedElements = sort(entry, ruleSet, elements);
 
         Set<Item> items =
                 classes.stream()
@@ -263,12 +263,12 @@ public class UtilityClassValidator implements RecommendationValidator, Initializ
         return styles;
     }
 
-    protected Map<Selector, List<HTMLElement>> sort(String componentName, RuleSet ruleSet, List<HTMLElement> elements) {
+    protected Map<Selector, List<HTMLElement>> sort(Entry entry, RuleSet ruleSet, List<HTMLElement> elements) {
         Map<Selector, List<HTMLElement>> results = new LinkedHashMap<>();
 
         for (Selector selector : ruleSet.getRule().selectors()) {
             List<HTMLElement> selectedElements =
-                    utilities.select(componentName, selector.toString(false), elements);
+                    utilities.select(entry, selector.toString(false), elements);
 
             if (selectedElements.isEmpty() == false) {
                 results.put(selector, selectedElements);


### PR DESCRIPTION
Resolves forcedotcom/salesforcedx-vscode-slds#32.

This change filter out utility classes recommendation when the following conditions are met

1. The identified elements are children of a dynamic tag, such as `<aura:iteration>`, `<template for:item for:each>`, `<template iterator:it>`. In the snippet below, `<li>` meets this criteria.

```
<template>
    <lightning-card title="HelloForEach" icon-name="custom:custom14">
        <ul class="slds-m-around_medium">
            <template for:each={contacts} for:item="contact">
                <li key={contact.Id}>
                    {contact.Name}, {contact.Title}
                </li>
            </template>
        </ul>
    </lightning-card>
</template>
```

2. The following Pseudo classes are used in the selector

|Selector | Example | Description |
|---- | ---- | ---- |
|:first-child|p:first-child|Selects every \<p\> elements that is the first child of its parent|
|:first-of-type|p:first-of-type|Selects every \<p\> element that is the first \<p\> element of its parent|
|:last-child|p:last-child|Selects every \<p\> elements that is the last child of its parent|
|:last-of-type|p:last-of-type|Selects every \<p\> element that is the last \<p\> element of its parent|
|:nth-child(n)|p:nth-child(2)|Selects every \<p\> element that is the second child of its parent|
|:nth-last-child(n)|p:nth-last-child(2)|Selects every \<p\> element that is the second child of its parent, counting from the last child|
|:nth-last-of-type(n)|p:nth-last-of-type(2)|Selects every \<p\> element that is the second \<p\> element of its parent, counting from the last child|
|:nth-of-type(n)|p:nth-of-type(2)|Selects every \<p\> element that is the second \<p\> element of its parent|
|:only-of-type|p:only-of-type|Selects every \<p\> element that is the only \<p\> element of its parent|
|:only-child|p:only-child|Selects every \<p\> element that is the only child of its parent|

