### PR TITLE
Add ability to suppress warnings via Quick Fix actions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.salesforce.slds</groupId>
         <artifactId>common</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
     </parent>
 
     <artifactId>core</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
 
     <dependencies>
         <dependency>

--- a/core/src/main/java/com/salesforce/slds/shared/models/annotations/AnnotationType.java
+++ b/core/src/main/java/com/salesforce/slds/shared/models/annotations/AnnotationType.java
@@ -9,8 +9,9 @@ package com.salesforce.slds.shared.models.annotations;
 
 public enum AnnotationType {
 
-    ALLOW("sldsValidatorAllow"),
-    IGNORE("sldsValidatorIgnore"),
+    ALLOW("sldsValidatorAllow"), // enables recommendation validation
+    IGNORE("sldsValidatorIgnore"), // disables recommendation validation
+    IGNORE_NEXT_LINE("sldsValidatorIgnoreNextLine"), // disables recommendation validation only for the next immediate line (even if an element is defined across multiple lines)
     WARN("sldsValidatorWarn"),
     NONE(null);
 
@@ -25,7 +26,7 @@ public enum AnnotationType {
     }
 
     public boolean validate() {
-        return this != ALLOW;
+        return this != IGNORE && this != IGNORE_NEXT_LINE;
     }
 
 }

--- a/core/src/main/java/com/salesforce/slds/shared/models/context/ContextKey.java
+++ b/core/src/main/java/com/salesforce/slds/shared/models/context/ContextKey.java
@@ -17,7 +17,8 @@ public enum ContextKey {
     INVALID,
     OVERRIDE,
     UTILITY_CLASS,
-    DESIGN_TOKEN;
+    DESIGN_TOKEN,
+    SLDS_MOBILE_VALIDATION;
 
     public static Optional<ContextKey> get(String name) {
         for (ContextKey key : values()) {

--- a/core/src/main/java/com/salesforce/slds/validation/processors/Processor.java
+++ b/core/src/main/java/com/salesforce/slds/validation/processors/Processor.java
@@ -7,11 +7,12 @@
 
 package com.salesforce.slds.validation.processors;
 
+import com.salesforce.slds.shared.models.core.Entry;
 import com.salesforce.slds.shared.models.recommendation.Recommendation;
 
 import java.util.List;
 
 public interface Processor {
 
-    List<Recommendation> process(List<Recommendation> recommendations);
+    List<Recommendation> process(Entry entry, List<Recommendation> recommendations);
 }

--- a/core/src/main/java/com/salesforce/slds/validation/processors/SortAndFilterProcessor.java
+++ b/core/src/main/java/com/salesforce/slds/validation/processors/SortAndFilterProcessor.java
@@ -7,6 +7,8 @@
 
 package com.salesforce.slds.validation.processors;
 
+import com.salesforce.slds.shared.models.core.Entry;
+import com.salesforce.slds.shared.models.core.HTMLElement;
 import com.salesforce.slds.shared.models.locations.Range;
 import com.salesforce.slds.shared.models.recommendation.Action;
 import com.salesforce.slds.shared.models.recommendation.ActionType;
@@ -17,17 +19,20 @@ import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 @Lazy
 public class SortAndFilterProcessor implements Processor {
 
     @Override
-    public List<Recommendation> process(List<Recommendation> recommendations) {
+    public List<Recommendation> process(Entry entry, List<Recommendation> recommendations) {
         List<Range> ranges = extractUtilitiesRange(recommendations);
+        List<Range> recommendationSuppressionRanges = entry.getRecommendationSuppressionRanges();
 
         return recommendations.stream()
                 .filter(recommendation -> containItems(recommendation) && filter(recommendation, ranges))
+                .filter(recommendation -> !shouldSkipRecommendation(recommendationSuppressionRanges, recommendation))
                 .map(this::sort)
                 .sorted(Recommendation::compareTo)
                 .collect(Collectors.toList());
@@ -60,5 +65,30 @@ public class SortAndFilterProcessor implements Processor {
 
         recommendation.setItems(items);
         return recommendation;
+    }
+
+    private boolean shouldSkipRecommendation(List<Range> recommendationSuppressionRanges, Recommendation recommendation) {
+        HTMLElement element = recommendation.getElement();
+
+        // For now we only apply the filtering to inputs of type Markup. This is because CSS
+        // files are filtered differently (using annotations) at the time when recommendations
+        // are being created, and that filtering logic is a bit different. So if we applied the
+        // filtering to CSS files here as well, then it would break backwards compatibility.
+        // Once we figure out a good way to address backwards compatibility, we should update
+        // this here to include all file types using the exact filtering logic used here 
+        // in order to keep things consistent.
+        if (element == null) {
+            return false;
+        }
+
+        Range elementRange = element.getRange();
+        return recommendationSuppressionRanges.stream().anyMatch(range ->
+            range.within(elementRange) || // completely contained withing the ignore range
+            (
+                    // next line is meant to be ignored and the element indeed starts as the next line
+                    range.getStart().getLine() == range.getEnd().getLine() &&
+                    range.getStart().getLine() == elementRange.getStart().getLine()
+            )
+        );
     }
 }

--- a/core/src/main/java/com/salesforce/slds/validation/runners/ValidateRunner.java
+++ b/core/src/main/java/com/salesforce/slds/validation/runners/ValidateRunner.java
@@ -104,7 +104,6 @@ public class ValidateRunner implements Runnable {
             setup();
 
             for (Entry entry : bundle.getEntries()) {
-
                 List<Recommendation> recommendations = validators.parallelStream()
                         .filter(validator -> validator instanceof RecommendationValidator)
                         .map(validator -> (RecommendationValidator) validator)
@@ -112,7 +111,7 @@ public class ValidateRunner implements Runnable {
                         .flatMap(List::stream)
                         .collect(aggregator.toList());
 
-                entry.setRecommendation(processor.process(recommendations));
+                entry.setRecommendation(processor.process(entry, recommendations));
 
                 List<ComponentOverride> overrides = validators.parallelStream()
                         .filter(validator -> validator instanceof OverrideValidator)

--- a/core/src/main/java/com/salesforce/slds/validation/validators/impl/recommendation/MobileSLDS_MarkupFriendlyValidator.java
+++ b/core/src/main/java/com/salesforce/slds/validation/validators/impl/recommendation/MobileSLDS_MarkupFriendlyValidator.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.salesforce.slds.shared.models.context.Context;
+import com.salesforce.slds.shared.models.context.ContextKey;
 import com.salesforce.slds.shared.models.core.Bundle;
 import com.salesforce.slds.shared.models.core.Entry;
 import com.salesforce.slds.shared.models.core.HTMLElement;
@@ -43,7 +44,8 @@ public class MobileSLDS_MarkupFriendlyValidator implements RecommendationValidat
 
     @Override
     public List<Recommendation> matches(Entry entry, Bundle bundle, Context context) {
-        if (entry.getEntityType() != Entry.EntityType.LWC) {
+        if (!context.isEnabled(ContextKey.SLDS_MOBILE_VALIDATION) ||
+            entry.getEntityType() != Entry.EntityType.LWC) {
             return Lists.newArrayList();
         }
 

--- a/core/src/main/java/com/salesforce/slds/validation/validators/impl/recommendation/MobileSLDS_MarkupLabelValidator.java
+++ b/core/src/main/java/com/salesforce/slds/validation/validators/impl/recommendation/MobileSLDS_MarkupLabelValidator.java
@@ -10,6 +10,7 @@ package com.salesforce.slds.validation.validators.impl.recommendation;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.salesforce.slds.shared.models.context.Context;
+import com.salesforce.slds.shared.models.context.ContextKey;
 import com.salesforce.slds.shared.models.core.Bundle;
 import com.salesforce.slds.shared.models.core.Entry;
 import com.salesforce.slds.shared.models.core.HTMLElement;
@@ -75,7 +76,8 @@ public class MobileSLDS_MarkupLabelValidator implements RecommendationValidator,
     @Override
     public List<Recommendation> matches(Entry entry, Bundle bundle, Context context) {
         // Only validate for LWC source code.
-        if (entry.getEntityType() != Entry.EntityType.LWC) {
+        if (!context.isEnabled(ContextKey.SLDS_MOBILE_VALIDATION) ||
+            entry.getEntityType() != Entry.EntityType.LWC) {
             return Lists.newArrayList();
         }
 
@@ -107,7 +109,8 @@ public class MobileSLDS_MarkupLabelValidator implements RecommendationValidator,
                     String tag = htmlElement.getContent().tagName();
 
                     Action action = Action.builder()
-                            .value(htmlElement.getContent().outerHtml()).range(htmlElement.getRange())
+                            .value(htmlElement.getContent().outerHtml())
+                            .range(htmlElement.getRange())
                             .description(REQUIRE_LABELS)
                             .name(tag)
                             .actionType(ActionType.NONE)

--- a/core/src/test/java/com/salesforce/slds/validation/processors/SortAndFilterProcessorTests.java
+++ b/core/src/test/java/com/salesforce/slds/validation/processors/SortAndFilterProcessorTests.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.slds.validation.processors;
+
+import com.google.common.collect.Lists;
+
+import com.salesforce.slds.configuration.SldsConfiguration;
+import com.salesforce.slds.shared.models.core.Bundle;
+import com.salesforce.slds.shared.models.core.Entry;
+import com.salesforce.slds.shared.models.core.Input;
+import com.salesforce.slds.shared.models.core.RuleSet;
+import com.salesforce.slds.shared.models.core.Style;
+import com.salesforce.slds.shared.models.locations.Location;
+import com.salesforce.slds.shared.models.locations.Range;
+import com.salesforce.slds.shared.models.recommendation.Action;
+import com.salesforce.slds.shared.models.recommendation.ActionType;
+import com.salesforce.slds.shared.models.recommendation.Item;
+import com.salesforce.slds.shared.models.recommendation.Recommendation;
+import com.salesforce.slds.shared.parsers.markup.MarkupParser;
+import com.salesforce.slds.validation.runners.ValidateRunner;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = SldsConfiguration.class)
+class SortAndFilterProcessorTests {
+
+    @Autowired
+    private ValidateRunner runner;
+
+    private final Processor processor = new SortAndFilterProcessor();
+
+    @Test
+    void sort() {
+        Set<Item> items = createItemSet("{padding: 0;}", Action.builder().build());
+
+        Recommendation rec1 = Recommendation.builder()
+                .input(RuleSet.builder().content("b {padding: 0;}").build())
+                .items(items).build();
+
+        Recommendation rec2 = Recommendation.builder()
+                .input(RuleSet.builder().content("a {padding: 0;}").build())
+                .items(items).build();
+
+        List<Recommendation> recommendations = new ArrayList<>();
+        recommendations.add(rec1);
+        recommendations.add(rec2);
+
+        List<Recommendation> results = processor.process(Entry.builder().build(), recommendations);
+        assertThat(results, Matchers.iterableWithSize(2));
+        assertThat(results.get(0).getInput().toString(),
+                Matchers.is(RuleSet.builder().content("a {padding: 0;}").build().toString()));
+        assertThat(results.get(1).getInput().toString(),
+                Matchers.is(RuleSet.builder().content("b {padding: 0;}").build().toString()));
+    }
+
+    @Test
+    @DisplayName("Filter recommendation that doesn't contain item")
+    void filter() {
+        Recommendation rec = Recommendation.builder()
+                .input(RuleSet.builder().content("a {padding: 0;}").build())
+                .items(new LinkedHashSet<>()).build();
+
+        List<Recommendation> recommendations = new ArrayList<>();
+        recommendations.add(rec);
+
+        List<Recommendation> results = processor.process(Entry.builder().build(), recommendations);
+        assertThat(results, Matchers.iterableWithSize(0));
+    }
+
+    @Test
+    @DisplayName("Simple Ranking when Style Recommendation is within Range of Utility Recommendation")
+    void rankingWithinRange() {
+        RuleSet ruleSet = RuleSet.builder().content("a {padding: 0;}").build();
+
+        Action utilityAction = Action.builder()
+                .range(new Range(new Location(1, 3), new Location(3, 8)))
+                .actionType(ActionType.REPLACE).relatedInformation(new LinkedList<>()).build();
+
+        Recommendation rule = Recommendation.builder()
+                .input(ruleSet)
+                .items(createItemSet("{padding: 0;}", utilityAction)).build();
+
+        Action designAction = Action.builder()
+                .actionType(ActionType.REPLACE).build();
+
+        Recommendation style = Recommendation.builder()
+                .input(Style.builder().property("padding").value("0").declaration("a").range(
+                        new Range(new Location(2, 3), new Location(2, 8))
+                ).build())
+                .items(createItemSet("{padding: 0;}", designAction)).build();
+
+        List<Recommendation> recommendations = Arrays.asList(rule, style);
+
+        List<Recommendation> results = processor.process(Entry.builder().build(), recommendations);
+        assertThat(results, Matchers.iterableWithSize(1));
+        assertThat(results.get(0).getInput(), Matchers.is(ruleSet));
+    }
+
+    @Test
+    @DisplayName("Simple Ranking when Style Recommendation is not within Range of Utility Recommendation")
+    void rankingNegative() {
+        RuleSet ruleSet = RuleSet.builder().content("a {padding: 0;}").build();
+
+        Action utilityAction = Action.builder()
+                .range(new Range(new Location(1, 3), new Location(3, 8)))
+                .actionType(ActionType.REPLACE).relatedInformation(new LinkedList<>()).build();
+
+        Recommendation rule = Recommendation.builder()
+                .input(ruleSet)
+                .items(createItemSet("{padding: 0;}", utilityAction)).build();
+
+        Action designAction = Action.builder()
+                .actionType(ActionType.REPLACE).build();
+
+        Recommendation style = Recommendation.builder()
+                .input(Style.builder().property("margin").value("0")
+                        .range(new Range(new Location(1, 0), new Location(1, 2)))
+                        .declaration("a").build())
+                .items(createItemSet("{padding: 0;}", designAction)).build();
+
+        List<Recommendation> recommendations = Arrays.asList(rule, style);
+
+        List<Recommendation> results = processor.process(Entry.builder().build(), recommendations);
+        assertThat(results, Matchers.iterableWithSize(2));
+        assertThat(results.get(0).getInput(), Matchers.is(ruleSet));
+    }
+
+    @Test
+    @DisplayName("Filter recommendations that should be suppressed")
+    void suppress() throws IOException {
+            URL resource = SortAndFilterProcessorTests.class.getResource("/components/mobileComponentExperience3.html");
+            File f = new File(resource.getFile());
+
+            Entry entry = Entry.builder().path(f.getPath()).rawContent(Files.readAllLines(f.toPath())).build();
+
+            Bundle bundle = new Bundle(entry);
+            runner.setBundle(bundle);
+
+            runner.run();
+
+            List<Recommendation> recommendations = runner.getBundle().getEntries().stream().map(Entry::getRecommendation)
+                    .flatMap(List::stream).collect(Collectors.toList());
+
+            assertThat(recommendations, Matchers.hasSize(1));
+
+            Map<String, List<Range>> results = new LinkedHashMap<>();
+            Map<String, String> messages = new HashMap<>();
+            recommendations.forEach(recommendation -> {
+            recommendation.getItems().stream()
+                    .forEach(item -> {
+                            for (Action action : item.getActions()) {
+                                List<Range> ranges = results.getOrDefault(action.getName(), new ArrayList<>());
+                                ranges.add(action.getRange());
+                                results.put(action.getName(), ranges);
+                                messages.put(action.getName(), action.getDescription());
+                        }
+                     });
+            });
+
+            assertThat(results.get("lightning-datatable"),
+                    Matchers.hasItem(new Range(new Location(18, 4), new Location(18, 47))));
+    }
+
+    private Set<Item> createItemSet(String value, Action ... actions) {
+        Set<Action> actionSet = new LinkedHashSet<>(Arrays.asList(actions));
+
+        Item item = new Item(value);
+        item.setActions(actionSet);
+
+        Set<Item> items = new LinkedHashSet<>();
+        items.add(item);
+
+        return items;
+    }
+}

--- a/core/src/test/java/com/salesforce/slds/validation/validators/AnnotationTest.java
+++ b/core/src/test/java/com/salesforce/slds/validation/validators/AnnotationTest.java
@@ -35,7 +35,7 @@ public class AnnotationTest {
 
     @Test
     public void blockAnnotationWithUtilityClasses() {
-        String declaration = " /*@sldsValidatorAllow*/ .THIS {\n" +
+        String declaration = " /*@sldsValidatorIgnore*/ .THIS {\n" +
                 "        overflow: hidden;\n" +
                 "    }";
 
@@ -51,10 +51,10 @@ public class AnnotationTest {
 
     @Test
     public void inlineAnnotation() {
-        String declaration = "/*@sldsValidatorIgnore*/\n" +
+        String declaration = "/*@sldsValidatorAllow*/\n" +
                 ".THIS .shareColumn .disabledPicklist {\n" +
                 "    min-width: 150px;\n" +
-                "    /*@sldsValidatorAllow*/ max-width: 240px;\n" +
+                "    /*@sldsValidatorIgnore*/ max-width: 240px;\n" +
                 "    margin-left: t(spacingLarge);\n" +
                 "    padding: 0 t(spacingMedium) 0 t(spacingMedium);\n" +
                 "    border: t(borderWidthThin) solid t(colorBorderInput);\n" +

--- a/core/src/test/java/com/salesforce/slds/validation/validators/CSSValidationTest.java
+++ b/core/src/test/java/com/salesforce/slds/validation/validators/CSSValidationTest.java
@@ -140,7 +140,7 @@ public class CSSValidationTest {
     @Test
     public void blockAnnotation() {
         StringBuilder builder = new StringBuilder();
-        builder.append("/* @sldsValidatorAllow */ .THIS { padding: 0; }")
+        builder.append("/* @sldsValidatorIgnore */ .THIS { padding: 0; }")
                 .append(System.lineSeparator())
                 .append(".THIS thead { display: block; }");
 
@@ -155,7 +155,7 @@ public class CSSValidationTest {
     @Test
     public void inlineAnnotation() {
         StringBuilder builder = new StringBuilder();
-        builder.append(".THIS { /* @sldsValidatorAllow */ padding: 0;")
+        builder.append(".THIS { /* @sldsValidatorIgnore */ padding: 0;")
                 .append(System.lineSeparator())
                 .append("padding: 0; }");
 

--- a/core/src/test/resources/components/mobileComponentExperience3.html
+++ b/core/src/test/resources/components/mobileComponentExperience3.html
@@ -1,0 +1,20 @@
+<template>
+    <!-- sldsValidatorIgnore -->
+    <lightning-datatable></lightning-datatable>
+    <lightning-flow-support></lightning-flow-support>
+    <!-- sldsValidatorAllow -->
+    <lightning-accordion></lightning-accordion>
+    <lightning-accordion></lightning-accordion>
+    <lightning-accordion></lightning-accordion>
+    <!-- sldsValidatorIgnore -->
+    <lightning-datatable></lightning-datatable>
+    <lightning-flow-support></lightning-flow-support>
+    <!-- sldsValidatorAllow -->
+    <lightning-accordion></lightning-accordion>
+    <lightning-accordion></lightning-accordion>
+    <lightning-accordion></lightning-accordion>
+    <!-- sldsValidatorIgnoreNextLine -->
+    <lightning-datatable>
+    </lightning-datatable>
+    <lightning-datatable></lightning-datatable>
+</template>

--- a/lsp/pom.xml
+++ b/lsp/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.salesforce.slds</groupId>
         <artifactId>common</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
     </parent>
 
     <artifactId>lsp</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
 
     <dependencies>
         <!-- Google Collection -->
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.salesforce.slds</groupId>
             <artifactId>core</artifactId>
-            <version>0.0.11</version>
+            <version>0.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lsp4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.salesforce.slds</groupId>
     <artifactId>common</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
 
     <modules>
         <module>core</module>


### PR DESCRIPTION
For mobile SLDS warnings in CSS/HTML files, this PR adds the ability to pick warning suppression actions from the Quick Fix menu.