### PR TITLE
Bump org.eclipse.lsp4j from 0.9.0 to 0.12.0 in /lsp

### DIFF
--- a/lsp/pom.xml
+++ b/lsp/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.eclipse.lsp4j</groupId>
             <artifactId>org.eclipse.lsp4j</artifactId>
-            <version>0.9.0</version>
+            <version>0.12.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This is to resolve https://avd.aquasec.com/nvd/2022/cve-2022-25647/. I chose 0.12.0, as it is the lowest version number to picks up gson 2.8.9. I did not test this other than what `mvn test` does.


```
┌───────────────────────────────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│                        Library                        │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├───────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ com.google.code.gson:gson (lsp-0.0.13-executable.jar) │ CVE-2022-25647 │ HIGH     │ 2.8.2             │ 2.8.9         │ Deserialization of Untrusted Data in                   │
│                                                       │                │          │                   │               │ com.google.code.gson-gson                              │
│                                                       │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-25647             │
├───────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
```